### PR TITLE
Delete require 'byebug' lines.

### DIFF
--- a/lib/code_generator/api_converter.rb
+++ b/lib/code_generator/api_converter.rb
@@ -1,5 +1,4 @@
 require 'json'
-require 'byebug'
 require 'set'
 require File.dirname(__FILE__) + '/helpers.rb'
 

--- a/lib/code_generator/code_generator.rb
+++ b/lib/code_generator/code_generator.rb
@@ -1,4 +1,3 @@
-require 'byebug'
 require 'json'
 require File.dirname(__FILE__) + '/helpers.rb'
 

--- a/lib/code_generator/helpers.rb
+++ b/lib/code_generator/helpers.rb
@@ -1,5 +1,4 @@
 require 'json'
-require 'byebug'
 
 module InstanceHelpers
   

--- a/lib/everscale-client-ruby.rb
+++ b/lib/everscale-client-ruby.rb
@@ -1,7 +1,6 @@
 require 'ffi'
 require "base64"
 require 'json'
-require 'byebug'
 require 'dotenv'
 require 'fileutils'
 require_relative './everscale-client-ruby/Helpers/CommonHelpers.rb'


### PR DESCRIPTION
Hello @nerzh.
I faced an issue in production mode because the library is trying to `require 'byebug'`.
I believe it's incorrect because byebug only used in development mode. It shouldn't be in production.

```
LoadError: cannot load such file -- byebug
/home/wittyjudge/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/home/wittyjudge/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
/home/wittyjudge/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/loaded_features_index.rb:89:in `register'
/home/wittyjudge/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
/home/wittyjudge/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:44:in `require'
/home/wittyjudge/everscale-client-ruby/lib/everscale-client-ruby.rb:4:in `<main>'
/home/wittyjudge/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/home/wittyjudge/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
/home/wittyjudge/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/home/wittyjudge/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
/home/wittyjudge/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
/home/wittyjudge/.rvm/gems/ruby-2.6.3/gems/bundler-1.17.3/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
/home/wittyjudge/.rvm/gems/ruby-2.6.3/gems/bundler-1.17.3/lib/bundler/runtime.rb:76:in `each'
```
